### PR TITLE
feat: add entity definitions for quest-chain, energy, rating, and backup services

### DIFF
--- a/microservices/backup-service/src/backup/entities/backup.entity.ts
+++ b/microservices/backup-service/src/backup/entities/backup.entity.ts
@@ -1,0 +1,139 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum BackupStatus {
+  PENDING = 'pending',
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+export enum BackupType {
+  FULL = 'full',
+  INCREMENTAL = 'incremental',
+  SNAPSHOT = 'snapshot',
+}
+
+export enum RestoreStatus {
+  PENDING = 'pending',
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+@Entity('backups')
+export class Backup {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({
+    type: 'enum',
+    enum: BackupType,
+    default: BackupType.SNAPSHOT,
+  })
+  backupType: BackupType;
+
+  @Column({
+    type: 'enum',
+    enum: BackupStatus,
+    default: BackupStatus.PENDING,
+  })
+  status: BackupStatus;
+
+  @Column({ nullable: true })
+  storagePath: string;
+
+  @Column({ type: 'bigint', nullable: true })
+  sizeBytes: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expiresAt: Date;
+
+  @Column({ nullable: true })
+  errorMessage: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('backup_schedules')
+export class BackupSchedule {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  cronExpression: string;
+
+  @Column({
+    type: 'enum',
+    enum: BackupType,
+    default: BackupType.INCREMENTAL,
+  })
+  backupType: BackupType;
+
+  @Column({ type: 'int', default: 7 })
+  retentionDays: number;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastRunAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  nextRunAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('restore_requests')
+export class RestoreRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  backupId: string;
+
+  @Column()
+  requestedBy: string;
+
+  @Column({
+    type: 'enum',
+    enum: RestoreStatus,
+    default: RestoreStatus.PENDING,
+  })
+  status: RestoreStatus;
+
+  @Column({ nullable: true })
+  targetEnvironment: string;
+
+  @Column({ nullable: true })
+  errorMessage: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  completedAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/microservices/energy-service/src/energy/entities/energy.entity.ts
+++ b/microservices/energy-service/src/energy/entities/energy.entity.ts
@@ -1,0 +1,104 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum TransactionType {
+  CONSUME = 'consume',
+  REFILL = 'refill',
+  REGEN = 'regen',
+}
+
+export enum RefillType {
+  TOKEN = 'token',
+  TIME = 'time',
+  REWARD = 'reward',
+}
+
+@Entity('energy_accounts')
+export class EnergyAccount {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  userId: string;
+
+  @Column({ type: 'int', default: 100 })
+  currentEnergy: number;
+
+  @Column({ type: 'int', default: 100 })
+  maxEnergy: number;
+
+  @Column({ type: 'int', default: 1 })
+  regenRatePerMinute: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastRegenAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('energy_transactions')
+export class EnergyTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column({ type: 'int' })
+  amount: number;
+
+  @Column({
+    type: 'enum',
+    enum: TransactionType,
+  })
+  type: TransactionType;
+
+  @Column({ nullable: true })
+  reason: string;
+
+  @Column({ type: 'int' })
+  balanceBefore: number;
+
+  @Column({ type: 'int' })
+  balanceAfter: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+
+@Entity('energy_refills')
+export class EnergyRefill {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column({ type: 'int' })
+  amount: number;
+
+  @Column({
+    type: 'enum',
+    enum: RefillType,
+    default: RefillType.TOKEN,
+  })
+  refillType: RefillType;
+
+  @Column({ nullable: true })
+  tokenCost: number;
+
+  @Column({ default: false })
+  applied: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/microservices/quest-chain-service/src/quest-chain/entities/quest-chain.entity.ts
+++ b/microservices/quest-chain-service/src/quest-chain/entities/quest-chain.entity.ts
@@ -1,0 +1,110 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum QuestChainStatus {
+  ACTIVE = 'active',
+  COMPLETED = 'completed',
+  LOCKED = 'locked',
+}
+
+export enum NodeType {
+  SEQUENTIAL = 'sequential',
+  BRANCH = 'branch',
+  CHECKPOINT = 'checkpoint',
+}
+
+@Entity('quest_chains')
+export class QuestChain {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column('text')
+  description: string;
+
+  @Column({
+    type: 'enum',
+    enum: QuestChainStatus,
+    default: QuestChainStatus.LOCKED,
+  })
+  status: QuestChainStatus;
+
+  @Column({ default: false })
+  isActive: boolean;
+
+  @OneToMany(() => QuestNode, (node) => node.chain)
+  nodes: QuestNode[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('quest_nodes')
+export class QuestNode {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  questId: string;
+
+  @Column({ type: 'int', default: 0 })
+  orderIndex: number;
+
+  @Column({
+    type: 'enum',
+    enum: NodeType,
+    default: NodeType.SEQUENTIAL,
+  })
+  nodeType: NodeType;
+
+  @Column({ default: false })
+  isCheckpoint: boolean;
+
+  @Column({ nullable: true })
+  prerequisiteNodeId: string;
+
+  @ManyToOne(() => QuestChain, (chain) => chain.nodes)
+  chain: QuestChain;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}
+
+@Entity('quest_chain_progress')
+export class QuestChainProgress {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  chainId: string;
+
+  @Column({ nullable: true })
+  lastCompletedNodeId: string;
+
+  @Column({ default: false })
+  completed: boolean;
+
+  @Column({ type: 'jsonb', nullable: true })
+  checkpointData: Record<string, unknown>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/microservices/rating-service/src/rating/entities/rating.entity.ts
+++ b/microservices/rating-service/src/rating/entities/rating.entity.ts
@@ -1,0 +1,113 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum ReviewStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  FLAGGED = 'flagged',
+  REMOVED = 'removed',
+}
+
+export enum VoteType {
+  HELPFUL = 'helpful',
+  NOT_HELPFUL = 'not_helpful',
+}
+
+@Entity('ratings')
+export class Rating {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  targetId: string;
+
+  @Column()
+  targetType: string;
+
+  @Column({ type: 'decimal', precision: 3, scale: 2 })
+  score: number;
+
+  @Column({ type: 'decimal', precision: 3, scale: 2, default: 0 })
+  averageScore: number;
+
+  @Column({ type: 'int', default: 0 })
+  totalRatings: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('reviews')
+export class Review {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  targetId: string;
+
+  @Column()
+  targetType: string;
+
+  @Column('text')
+  content: string;
+
+  @Column({ type: 'int', default: 0 })
+  helpfulVotes: number;
+
+  @Column({ type: 'int', default: 0 })
+  notHelpfulVotes: number;
+
+  @Column({
+    type: 'enum',
+    enum: ReviewStatus,
+    default: ReviewStatus.PENDING,
+  })
+  status: ReviewStatus;
+
+  @Column({ default: false })
+  isFlagged: boolean;
+
+  @Column({ nullable: true })
+  moderationNote: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+@Entity('review_votes')
+export class ReviewVote {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  reviewId: string;
+
+  @Column({
+    type: 'enum',
+    enum: VoteType,
+  })
+  voteType: VoteType;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary

- Adds `QuestChain`, `QuestNode`, and `QuestChainProgress` entities for sequential/branching quest chain tracking with progress checkpointing (closes #280)
- Adds `EnergyAccount`, `EnergyTransaction`, and `EnergyRefill` entities for energy/stamina consumption, time-based regeneration, and token refills (closes #281)
- Adds `Rating`, `Review`, and `ReviewVote` entities for aggregated ratings, user reviews with moderation flags, and helpful/unhelpful voting (closes #282)
- Adds `Backup`, `BackupSchedule`, and `RestoreRequest` entities for automated backup scheduling, snapshots with retention policies, and restore tracking (closes #283)

closes #280
closes #281
closes #282
closes #283