### PR TITLE
feat: set up metrics, referral growth, tournament management, and audit log services

### DIFF
--- a/src/logging/services/audit-log.service.ts
+++ b/src/logging/services/audit-log.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export type AuditAction =
+  | 'user.login'
+  | 'user.logout'
+  | 'quest.start'
+  | 'quest.complete'
+  | 'tournament.join'
+  | 'tournament.start'
+  | 'referral.created'
+  | 'admin.action';
+
+export interface AuditEntry {
+  id: string;
+  action: AuditAction;
+  actorId: string;
+  targetId?: string;
+  metadata?: Record<string, unknown>;
+  occurredAt: Date;
+}
+
+@Injectable()
+export class AuditLogService {
+  private readonly logger = new Logger(AuditLogService.name);
+  private readonly entries: AuditEntry[] = [];
+  private counter = 1;
+
+  log(
+    action: AuditAction,
+    actorId: string,
+    targetId?: string,
+    metadata?: Record<string, unknown>,
+  ): AuditEntry {
+    const entry: AuditEntry = {
+      id: `audit-${this.counter++}`,
+      action,
+      actorId,
+      targetId,
+      metadata,
+      occurredAt: new Date(),
+    };
+    this.entries.push(entry);
+    this.logger.log(`[audit] ${action} | actor=${actorId}${targetId ? ` target=${targetId}` : ''}`);
+    return entry;
+  }
+
+  findByActor(actorId: string): AuditEntry[] {
+    return this.entries.filter((e) => e.actorId === actorId);
+  }
+
+  findByAction(action: AuditAction): AuditEntry[] {
+    return this.entries.filter((e) => e.action === action);
+  }
+
+  findAll(): AuditEntry[] {
+    return [...this.entries];
+  }
+}

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface MetricSnapshot {
+  key: string;
+  value: number;
+  recordedAt: Date;
+}
+
+@Injectable()
+export class MetricsService {
+  private readonly logger = new Logger(MetricsService.name);
+  private readonly counters = new Map<string, number>();
+  private readonly history: MetricSnapshot[] = [];
+
+  increment(key: string, by = 1): void {
+    const current = this.counters.get(key) ?? 0;
+    this.counters.set(key, current + by);
+    this.history.push({ key, value: current + by, recordedAt: new Date() });
+    this.logger.debug(`[metric] ${key} = ${current + by}`);
+  }
+
+  get(key: string): number {
+    return this.counters.get(key) ?? 0;
+  }
+
+  snapshot(): Record<string, number> {
+    return Object.fromEntries(this.counters.entries());
+  }
+
+  history_for(key: string): MetricSnapshot[] {
+    return this.history.filter((s) => s.key === key);
+  }
+
+  reset(key: string): void {
+    this.counters.delete(key);
+  }
+}

--- a/src/referrals/referral-growth.service.ts
+++ b/src/referrals/referral-growth.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface GrowthStats {
+  totalReferrals: number;
+  conversionRate: number;
+  topReferrers: Array<{ userId: string; count: number }>;
+}
+
+@Injectable()
+export class ReferralGrowthService {
+  private readonly logger = new Logger(ReferralGrowthService.name);
+  private readonly referralCounts = new Map<string, number>();
+  private totalConverted = 0;
+  private totalAttempted = 0;
+
+  recordReferral(referrerId: string, converted: boolean): void {
+    const count = (this.referralCounts.get(referrerId) ?? 0) + 1;
+    this.referralCounts.set(referrerId, count);
+    this.totalAttempted += 1;
+    if (converted) {
+      this.totalConverted += 1;
+    }
+    this.logger.log(`Referral recorded for ${referrerId} — converted: ${converted}`);
+  }
+
+  getStats(): GrowthStats {
+    const topReferrers = [...this.referralCounts.entries()]
+      .map(([userId, count]) => ({ userId, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    return {
+      totalReferrals: this.totalAttempted,
+      conversionRate: this.totalAttempted > 0
+        ? this.totalConverted / this.totalAttempted
+        : 0,
+      topReferrers,
+    };
+  }
+
+  getReferralCount(referrerId: string): number {
+    return this.referralCounts.get(referrerId) ?? 0;
+  }
+}

--- a/src/tournaments/tournament-management.service.ts
+++ b/src/tournaments/tournament-management.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+
+export type TournamentStatus = 'pending' | 'active' | 'completed' | 'cancelled';
+
+export interface Tournament {
+  id: string;
+  name: string;
+  status: TournamentStatus;
+  maxParticipants: number;
+  participants: string[];
+  startAt: Date;
+  createdAt: Date;
+}
+
+@Injectable()
+export class TournamentManagementService {
+  private readonly logger = new Logger(TournamentManagementService.name);
+  private readonly tournaments = new Map<string, Tournament>();
+  private counter = 1;
+
+  create(name: string, maxParticipants: number, startAt: Date): Tournament {
+    const id = `tournament-${this.counter++}`;
+    const tournament: Tournament = {
+      id,
+      name,
+      status: 'pending',
+      maxParticipants,
+      participants: [],
+      startAt,
+      createdAt: new Date(),
+    };
+    this.tournaments.set(id, tournament);
+    this.logger.log(`Tournament created: ${id} — "${name}"`);
+    return tournament;
+  }
+
+  join(tournamentId: string, userId: string): Tournament {
+    const tournament = this.findOrThrow(tournamentId);
+
+    if (tournament.status !== 'pending') {
+      throw new BadRequestException(`Tournament "${tournamentId}" is not open for registration.`);
+    }
+    if (tournament.participants.includes(userId)) {
+      throw new BadRequestException(`User ${userId} is already registered.`);
+    }
+    if (tournament.participants.length >= tournament.maxParticipants) {
+      throw new BadRequestException(`Tournament "${tournamentId}" is full.`);
+    }
+
+    tournament.participants.push(userId);
+    return tournament;
+  }
+
+  start(tournamentId: string): Tournament {
+    const tournament = this.findOrThrow(tournamentId);
+    if (tournament.status !== 'pending') {
+      throw new BadRequestException(`Only pending tournaments can be started.`);
+    }
+    tournament.status = 'active';
+    this.logger.log(`Tournament started: ${tournamentId}`);
+    return tournament;
+  }
+
+  complete(tournamentId: string): Tournament {
+    const tournament = this.findOrThrow(tournamentId);
+    if (tournament.status !== 'active') {
+      throw new BadRequestException(`Only active tournaments can be completed.`);
+    }
+    tournament.status = 'completed';
+    this.logger.log(`Tournament completed: ${tournamentId}`);
+    return tournament;
+  }
+
+  findById(id: string): Tournament | undefined {
+    return this.tournaments.get(id);
+  }
+
+  private findOrThrow(id: string): Tournament {
+    const t = this.tournaments.get(id);
+    if (!t) throw new NotFoundException(`Tournament "${id}" not found.`);
+    return t;
+  }
+}


### PR DESCRIPTION
## Summary

- **MetricsService** (`src/metrics/metrics.service.ts`): lightweight in-memory counter store with increment, snapshot, per-key history, and reset operations.
- **ReferralGrowthService** (`src/referrals/referral-growth.service.ts`): tracks referral attempts and conversions per referrer, computes overall conversion rate, and surfaces top-10 referrers.
- **TournamentManagementService** (`src/tournaments/tournament-management.service.ts`): full tournament lifecycle — create, join (with capacity and duplicate checks), start, and complete — with typed status transitions.
- **AuditLogService** (`src/logging/services/audit-log.service.ts`): structured compliance event logger with typed action enum, actor/target tracking, and query helpers by actor or action.

closes #276
closes #277
closes #278
closes #279