### PR TITLE
feat: initialize quiz-service microservice

### DIFF
--- a/microservices/quiz-service/Dockerfile
+++ b/microservices/quiz-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY dist ./dist
+CMD ["node", "dist/main"]

--- a/microservices/quiz-service/nest-cli.json
+++ b/microservices/quiz-service/nest-cli.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json.schemastore.org/nest-cli","collection":"@nestjs/schematics","sourceRoot":"src"}

--- a/microservices/quiz-service/package.json
+++ b/microservices/quiz-service/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "quiz-service",
+  "version": "0.0.1",
+  "description": "Quiz and trivia service for quick games and knowledge challenges",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,test}/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit",
+    "test": "jest",
+    "test:cov": "jest --coverage"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.4",
+    "@nestjs/config": "^3.2.3",
+    "@nestjs/core": "^10.4.4",
+    "@nestjs/platform-express": "^10.4.4",
+    "@nestjs/typeorm": "^11.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "pg": "^8.13.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.20"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.5",
+    "@nestjs/schematics": "^10.1.4",
+    "@nestjs/testing": "^10.4.4",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.15",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js", "json", "ts"],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": { "^.+\\.(t|j)s$": "ts-jest" },
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/microservices/quiz-service/src/app.module.ts
+++ b/microservices/quiz-service/src/app.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Quiz } from './quiz.entity';
+import { QuizService } from './quiz.service';
+import { QuizController } from './quiz.controller';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (config: ConfigService) => ({
+        type: 'postgres',
+        url: config.get('DATABASE_URL'),
+        entities: [Quiz],
+        synchronize: true,
+      }),
+      inject: [ConfigService],
+    }),
+    TypeOrmModule.forFeature([Quiz]),
+  ],
+  controllers: [QuizController],
+  providers: [QuizService],
+})
+export class AppModule {}

--- a/microservices/quiz-service/src/main.ts
+++ b/microservices/quiz-service/src/main.ts
@@ -1,0 +1,11 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.enableCors();
+  const port = process.env.PORT || 3010;
+  await app.listen(port, '0.0.0.0');
+  console.log(`Quiz Service running on port ${port}`);
+}
+bootstrap();

--- a/microservices/quiz-service/src/quiz.controller.ts
+++ b/microservices/quiz-service/src/quiz.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Post, Body, Param, Query } from '@nestjs/common';
+import { QuizService } from './quiz.service';
+import { Quiz } from './quiz.entity';
+
+@Controller('quizzes')
+export class QuizController {
+  constructor(private readonly quizService: QuizService) {}
+
+  @Post()
+  create(@Body() body: Partial<Quiz>): Promise<Quiz> {
+    return this.quizService.create(body);
+  }
+
+  @Get()
+  findAll(@Query('category') category?: string): Promise<Quiz[]> {
+    if (category) return this.quizService.findByCategory(category);
+    return this.quizService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<Quiz | null> {
+    return this.quizService.findOne(id);
+  }
+}

--- a/microservices/quiz-service/src/quiz.entity.ts
+++ b/microservices/quiz-service/src/quiz.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('quizzes')
+export class Quiz {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  category: string;
+
+  @Column({ default: 30 })
+  timeLimitSeconds: number;
+
+  @Column({ default: false })
+  isMultiplayer: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/microservices/quiz-service/src/quiz.service.spec.ts
+++ b/microservices/quiz-service/src/quiz.service.spec.ts
@@ -1,0 +1,35 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { QuizService } from './quiz.service';
+import { Quiz } from './quiz.entity';
+
+describe('QuizService', () => {
+  let service: QuizService;
+  const mockRepo = {
+    create: jest.fn((d) => d),
+    save: jest.fn((d) => Promise.resolve({ id: 'uuid', ...d })),
+    find: jest.fn(() => Promise.resolve([])),
+    findOneBy: jest.fn(() => Promise.resolve(null)),
+    findBy: jest.fn(() => Promise.resolve([])),
+  };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        QuizService,
+        { provide: getRepositoryToken(Quiz), useValue: mockRepo },
+      ],
+    }).compile();
+    service = module.get(QuizService);
+  });
+
+  it('creates a quiz', async () => {
+    const quiz = await service.create({ title: 'Test Quiz' });
+    expect(quiz.title).toBe('Test Quiz');
+  });
+
+  it('returns all quizzes', async () => {
+    const result = await service.findAll();
+    expect(Array.isArray(result)).toBe(true);
+  });
+});

--- a/microservices/quiz-service/src/quiz.service.ts
+++ b/microservices/quiz-service/src/quiz.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Quiz } from './quiz.entity';
+
+@Injectable()
+export class QuizService {
+  constructor(
+    @InjectRepository(Quiz)
+    private readonly quizRepo: Repository<Quiz>,
+  ) {}
+
+  create(data: Partial<Quiz>): Promise<Quiz> {
+    return this.quizRepo.save(this.quizRepo.create(data));
+  }
+
+  findAll(): Promise<Quiz[]> {
+    return this.quizRepo.find();
+  }
+
+  findOne(id: string): Promise<Quiz | null> {
+    return this.quizRepo.findOneBy({ id });
+  }
+
+  findByCategory(category: string): Promise<Quiz[]> {
+    return this.quizRepo.findBy({ category });
+  }
+}

--- a/microservices/quiz-service/tsconfig.build.json
+++ b/microservices/quiz-service/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"./tsconfig.json","exclude":["node_modules","test","dist","**/*spec.ts"]}

--- a/microservices/quiz-service/tsconfig.json
+++ b/microservices/quiz-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false
+  }
+}


### PR DESCRIPTION
## Summary
Initializes the microservices/quiz-service NestJS microservice for quiz and trivia games.

## Changes
- Quiz entity with title, category, time limit, and multiplayer flag
- QuizService with create, findAll, findOne, findByCategory methods
- QuizController exposing REST endpoints
- AppModule with TypeORM + PostgreSQL configuration
- Unit tests for QuizService
- Dockerfile for containerized deployment

## Implementation Plan
1. Entity and service layer with TypeORM
2. REST controller with category filtering
3. Unit tests with mocked repository
4. Docker configuration for independent deployment

## Rollback
Delete microservices/quiz-service/ directory.

closes #316