### PR TITLE
feat: initialize sync-service microservice

### DIFF
--- a/microservices/sync-service/Dockerfile
+++ b/microservices/sync-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY dist ./dist
+CMD ["node", "dist/main"]

--- a/microservices/sync-service/nest-cli.json
+++ b/microservices/sync-service/nest-cli.json
@@ -1,0 +1,1 @@
+{"$schema":"https://json.schemastore.org/nest-cli","collection":"@nestjs/schematics","sourceRoot":"src"}

--- a/microservices/sync-service/package.json
+++ b/microservices/sync-service/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "sync-service",
+  "version": "0.0.1",
+  "description": "Cross-device sync service for player progress and settings",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint \"{src,test}/**/*.ts\" --fix",
+    "type-check": "tsc --noEmit",
+    "test": "jest",
+    "test:cov": "jest --coverage"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.4",
+    "@nestjs/config": "^3.2.3",
+    "@nestjs/core": "^10.4.4",
+    "@nestjs/platform-express": "^10.4.4",
+    "@nestjs/typeorm": "^11.0.0",
+    "@nestjs/websockets": "^10.4.4",
+    "@nestjs/platform-ws": "^10.4.22",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "pg": "^8.13.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.20",
+    "ws": "^8.19.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.5",
+    "@nestjs/schematics": "^10.1.4",
+    "@nestjs/testing": "^10.4.4",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.15",
+    "@types/ws": "^8.18.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js", "json", "ts"],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": { "^.+\\.(t|j)s$": "ts-jest" },
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/microservices/sync-service/src/app.module.ts
+++ b/microservices/sync-service/src/app.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SyncState } from './sync.entity';
+import { SyncService } from './sync.service';
+import { SyncController } from './sync.controller';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRootAsync({
+      imports: [ConfigModule],
+      useFactory: (config: ConfigService) => ({
+        type: 'postgres',
+        url: config.get('DATABASE_URL'),
+        entities: [SyncState],
+        synchronize: true,
+      }),
+      inject: [ConfigService],
+    }),
+    TypeOrmModule.forFeature([SyncState]),
+  ],
+  controllers: [SyncController],
+  providers: [SyncService],
+})
+export class AppModule {}

--- a/microservices/sync-service/src/main.ts
+++ b/microservices/sync-service/src/main.ts
@@ -1,0 +1,11 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.enableCors();
+  const port = process.env.PORT || 3011;
+  await app.listen(port, '0.0.0.0');
+  console.log(`Sync Service running on port ${port}`);
+}
+bootstrap();

--- a/microservices/sync-service/src/sync.controller.ts
+++ b/microservices/sync-service/src/sync.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { SyncService } from './sync.service';
+
+@Controller('sync')
+export class SyncController {
+  constructor(private readonly syncService: SyncService) {}
+
+  @Post(':userId/:deviceId')
+  upsert(
+    @Param('userId') userId: string,
+    @Param('deviceId') deviceId: string,
+    @Body() data: Record<string, unknown>,
+  ) {
+    return this.syncService.upsert(userId, deviceId, data);
+  }
+
+  @Get(':userId/:deviceId')
+  getState(@Param('userId') userId: string, @Param('deviceId') deviceId: string) {
+    return this.syncService.getState(userId, deviceId);
+  }
+
+  @Get(':userId/devices')
+  getDevices(@Param('userId') userId: string) {
+    return this.syncService.getDevices(userId);
+  }
+}

--- a/microservices/sync-service/src/sync.entity.ts
+++ b/microservices/sync-service/src/sync.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, UpdateDateColumn } from 'typeorm';
+
+@Entity('sync_states')
+export class SyncState {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  deviceId: string;
+
+  @Column({ type: 'jsonb', default: {} })
+  data: Record<string, unknown>;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/microservices/sync-service/src/sync.service.spec.ts
+++ b/microservices/sync-service/src/sync.service.spec.ts
@@ -1,0 +1,36 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SyncService } from './sync.service';
+import { SyncState } from './sync.entity';
+
+describe('SyncService', () => {
+  let service: SyncService;
+  const existing = { id: 'uuid', userId: 'u1', deviceId: 'd1', data: { level: 1 }, updatedAt: new Date() };
+  const mockRepo = {
+    create: jest.fn((d) => d),
+    save: jest.fn((d) => Promise.resolve({ id: 'uuid', ...d })),
+    findOneBy: jest.fn(() => Promise.resolve(null)),
+    findBy: jest.fn(() => Promise.resolve([])),
+  };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        SyncService,
+        { provide: getRepositoryToken(SyncState), useValue: mockRepo },
+      ],
+    }).compile();
+    service = module.get(SyncService);
+  });
+
+  it('creates new sync state', async () => {
+    const result = await service.upsert('u1', 'd1', { level: 5 });
+    expect(result).toBeDefined();
+  });
+
+  it('merges data on conflict', async () => {
+    mockRepo.findOneBy.mockResolvedValueOnce({ ...existing });
+    const result = await service.upsert('u1', 'd1', { score: 100 });
+    expect(result).toBeDefined();
+  });
+});

--- a/microservices/sync-service/src/sync.service.ts
+++ b/microservices/sync-service/src/sync.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SyncState } from './sync.entity';
+
+@Injectable()
+export class SyncService {
+  constructor(
+    @InjectRepository(SyncState)
+    private readonly syncRepo: Repository<SyncState>,
+  ) {}
+
+  async upsert(userId: string, deviceId: string, data: Record<string, unknown>): Promise<SyncState> {
+    let state = await this.syncRepo.findOneBy({ userId, deviceId });
+    if (!state) {
+      state = this.syncRepo.create({ userId, deviceId, data });
+    } else {
+      // Last-write-wins conflict resolution
+      state.data = { ...state.data, ...data };
+    }
+    return this.syncRepo.save(state);
+  }
+
+  getState(userId: string, deviceId: string): Promise<SyncState | null> {
+    return this.syncRepo.findOneBy({ userId, deviceId });
+  }
+
+  getDevices(userId: string): Promise<SyncState[]> {
+    return this.syncRepo.findBy({ userId });
+  }
+}

--- a/microservices/sync-service/tsconfig.build.json
+++ b/microservices/sync-service/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends":"./tsconfig.json","exclude":["node_modules","test","dist","**/*spec.ts"]}

--- a/microservices/sync-service/tsconfig.json
+++ b/microservices/sync-service/tsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"module":"commonjs","declaration":true,"removeComments":true,"emitDecoratorMetadata":true,"experimentalDecorators":true,"allowSyntheticDefaultImports":true,"target":"ES2021","sourceMap":true,"outDir":"./dist","baseUrl":"./","incremental":true,"skipLibCheck":true,"strictNullChecks":false,"noImplicitAny":false}}


### PR DESCRIPTION
## Summary
Initializes the microservices/sync-service NestJS microservice for cross-device player data synchronization.

## Changes
- SyncState entity with userId, deviceId, and JSONB data field
- SyncService with upsert (last-write-wins conflict resolution), getState, getDevices
- SyncController exposing REST endpoints
- AppModule with TypeORM + PostgreSQL configuration
- Unit tests for SyncService
- Dockerfile for containerized deployment

## Implementation Plan
1. SyncState entity with JSONB data column
2. Last-write-wins conflict resolution in upsert
3. REST endpoints for state management
4. Unit tests with mocked repository

## Rollback
Delete microservices/sync-service/ directory.

closes #319