### PR TITLE
feat: Player Profile Management Service setup

### DIFF
--- a/microservices/profile-service/nest-cli.json
+++ b/microservices/profile-service/nest-cli.json
@@ -1,0 +1,1 @@
+{"$schema": "https://json.schemastore.org/nest-cli", "collection": "@nestjs/schematics", "sourceRoot": "src", "compilerOptions": {"deleteOutDir": true}}

--- a/microservices/profile-service/package.json
+++ b/microservices/profile-service/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "profile-service",
+  "version": "0.0.1",
+  "description": "Player profile management service",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.4",
+    "@nestjs/core": "^10.4.4",
+    "@nestjs/platform-express": "^10.4.4",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.5",
+    "@nestjs/testing": "^10.4.4",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.15",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js","json","ts"],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {"^.+\\.(t|j)s$": "ts-jest"},
+    "testEnvironment": "node"
+  }
+}

--- a/microservices/profile-service/src/app.module.ts
+++ b/microservices/profile-service/src/app.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { ProfileModule } from './profile/profile.module';
+
+@Module({ imports: [ProfileModule] })
+export class AppModule {}

--- a/microservices/profile-service/src/main.ts
+++ b/microservices/profile-service/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  const port = parseInt(process.env.SERVICE_PORT || '3011', 10);
+  await app.listen(port);
+  console.log(`Profile Service running on port ${port}`);
+}
+bootstrap();

--- a/microservices/profile-service/src/profile/profile.controller.spec.ts
+++ b/microservices/profile-service/src/profile/profile.controller.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+
+describe('ProfileController', () => {
+  let ctrl: ProfileController;
+  beforeEach(async () => {
+    const m: TestingModule = await Test.createTestingModule({
+      controllers: [ProfileController], providers: [ProfileService],
+    }).compile();
+    ctrl = m.get(ProfileController);
+  });
+  it('should be defined', () => expect(ctrl).toBeDefined());
+  it('creates a profile', () => {
+    const p = ctrl.create('u1', 'Alice');
+    expect(p.userId).toBe('u1');
+    expect(p.displayName).toBe('Alice');
+  });
+  it('throws for unknown user', () => {
+    expect(() => ctrl.findOne('ghost')).toThrow(NotFoundException);
+  });
+});

--- a/microservices/profile-service/src/profile/profile.controller.ts
+++ b/microservices/profile-service/src/profile/profile.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { ProfileService } from './profile.service';
+
+@Controller('profiles')
+export class ProfileController {
+  constructor(private readonly svc: ProfileService) {}
+
+  @Post()
+  create(@Body('userId') userId: string, @Body('displayName') dn: string) {
+    return this.svc.create(userId, dn);
+  }
+
+  @Get(':userId')
+  findOne(@Param('userId') userId: string) { return this.svc.findByUserId(userId); }
+
+  @Patch(':userId')
+  update(@Param('userId') userId: string, @Body() body: Record<string, string>) {
+    return this.svc.update(userId, body);
+  }
+}

--- a/microservices/profile-service/src/profile/profile.module.ts
+++ b/microservices/profile-service/src/profile/profile.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+
+@Module({ controllers: [ProfileController], providers: [ProfileService] })
+export class ProfileModule {}

--- a/microservices/profile-service/src/profile/profile.service.ts
+++ b/microservices/profile-service/src/profile/profile.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+export interface Profile { id: string; userId: string; displayName: string; bio: string; avatarUrl: string; }
+
+@Injectable()
+export class ProfileService {
+  private readonly profiles: Profile[] = [];
+
+  create(userId: string, displayName: string): Profile {
+    const p: Profile = { id: Date.now().toString(), userId, displayName, bio: '', avatarUrl: '' };
+    this.profiles.push(p);
+    return p;
+  }
+
+  findByUserId(userId: string): Profile {
+    const p = this.profiles.find((x) => x.userId === userId);
+    if (!p) throw new NotFoundException(`Profile not found for user ${userId}`);
+    return p;
+  }
+
+  update(userId: string, data: Partial<Pick<Profile, 'displayName' | 'bio' | 'avatarUrl'>>): Profile {
+    return Object.assign(this.findByUserId(userId), data);
+  }
+}

--- a/microservices/profile-service/tsconfig.build.json
+++ b/microservices/profile-service/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends": "./tsconfig.json", "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]}

--- a/microservices/profile-service/tsconfig.json
+++ b/microservices/profile-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2020",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Initialise `microservices/profile-service` as a standalone NestJS app (port 3011)
- `ProfileService` — in-memory CRUD: `create`, `findByUserId`, `update`
- `ProfileController` — `POST /profiles`, `GET /profiles/:userId`, `PATCH /profiles/:userId`
- Unit tests in `profile.controller.spec.ts`

Closes #305