### PR TITLE
feat: Guild and Team Management Service setup

### DIFF
--- a/microservices/guild-service/nest-cli.json
+++ b/microservices/guild-service/nest-cli.json
@@ -1,0 +1,1 @@
+{"$schema": "https://json.schemastore.org/nest-cli", "collection": "@nestjs/schematics", "sourceRoot": "src", "compilerOptions": {"deleteOutDir": true}}

--- a/microservices/guild-service/package.json
+++ b/microservices/guild-service/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "guild-service",
+  "version": "0.0.1",
+  "description": "Guild and team management service",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.4",
+    "@nestjs/core": "^10.4.4",
+    "@nestjs/platform-express": "^10.4.4",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.5",
+    "@nestjs/testing": "^10.4.4",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.15",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js","json","ts"],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {"^.+\\.(t|j)s$": "ts-jest"},
+    "testEnvironment": "node"
+  }
+}

--- a/microservices/guild-service/src/app.module.ts
+++ b/microservices/guild-service/src/app.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { GuildModule } from './guild/guild.module';
+
+@Module({ imports: [GuildModule] })
+export class AppModule {}

--- a/microservices/guild-service/src/guild/guild.controller.spec.ts
+++ b/microservices/guild-service/src/guild/guild.controller.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { GuildController } from './guild.controller';
+import { GuildService } from './guild.service';
+
+describe('GuildController', () => {
+  let ctrl: GuildController;
+  beforeEach(async () => {
+    const m: TestingModule = await Test.createTestingModule({
+      controllers: [GuildController], providers: [GuildService],
+    }).compile();
+    ctrl = m.get(GuildController);
+  });
+  it('should be defined', () => expect(ctrl).toBeDefined());
+  it('creates a guild with owner as first member', () => {
+    const g = ctrl.create('Alphas', 'owner1');
+    expect(g.name).toBe('Alphas');
+    expect(g.memberIds).toContain('owner1');
+  });
+  it('throws for unknown guild', () => {
+    expect(() => ctrl.findOne('none')).toThrow(NotFoundException);
+  });
+  it('adds and removes members', () => {
+    const g = ctrl.create('Betas', 'o1');
+    ctrl.addMember(g.id, 'm2');
+    expect(ctrl.findOne(g.id).memberIds).toContain('m2');
+    ctrl.removeMember(g.id, 'm2');
+    expect(ctrl.findOne(g.id).memberIds).not.toContain('m2');
+  });
+});

--- a/microservices/guild-service/src/guild/guild.controller.ts
+++ b/microservices/guild-service/src/guild/guild.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { GuildService } from './guild.service';
+
+@Controller('guilds')
+export class GuildController {
+  constructor(private readonly svc: GuildService) {}
+
+  @Post()
+  create(@Body('name') name: string, @Body('ownerId') ownerId: string) {
+    return this.svc.create(name, ownerId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) { return this.svc.findById(id); }
+
+  @Post(':id/members')
+  addMember(@Param('id') id: string, @Body('memberId') memberId: string) {
+    return this.svc.addMember(id, memberId);
+  }
+
+  @Delete(':id/members/:memberId')
+  removeMember(@Param('id') id: string, @Param('memberId') mid: string) {
+    return this.svc.removeMember(id, mid);
+  }
+}

--- a/microservices/guild-service/src/guild/guild.module.ts
+++ b/microservices/guild-service/src/guild/guild.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { GuildController } from './guild.controller';
+import { GuildService } from './guild.service';
+
+@Module({ controllers: [GuildController], providers: [GuildService] })
+export class GuildModule {}

--- a/microservices/guild-service/src/guild/guild.service.ts
+++ b/microservices/guild-service/src/guild/guild.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+export interface Guild { id: string; name: string; ownerId: string; memberIds: string[]; }
+
+@Injectable()
+export class GuildService {
+  private readonly guilds: Guild[] = [];
+
+  create(name: string, ownerId: string): Guild {
+    const g: Guild = { id: Date.now().toString(), name, ownerId, memberIds: [ownerId] };
+    this.guilds.push(g);
+    return g;
+  }
+
+  findById(id: string): Guild {
+    const g = this.guilds.find((x) => x.id === id);
+    if (!g) throw new NotFoundException(`Guild ${id} not found`);
+    return g;
+  }
+
+  addMember(guildId: string, memberId: string): Guild {
+    const g = this.findById(guildId);
+    if (!g.memberIds.includes(memberId)) g.memberIds.push(memberId);
+    return g;
+  }
+
+  removeMember(guildId: string, memberId: string): Guild {
+    const g = this.findById(guildId);
+    g.memberIds = g.memberIds.filter((id) => id !== memberId);
+    return g;
+  }
+}

--- a/microservices/guild-service/src/main.ts
+++ b/microservices/guild-service/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  const port = parseInt(process.env.SERVICE_PORT || '3012', 10);
+  await app.listen(port);
+  console.log(`Guild Service running on port ${port}`);
+}
+bootstrap();

--- a/microservices/guild-service/tsconfig.build.json
+++ b/microservices/guild-service/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends": "./tsconfig.json", "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]}

--- a/microservices/guild-service/tsconfig.json
+++ b/microservices/guild-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2020",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Initialise `microservices/guild-service` as a standalone NestJS app (port 3012)
- `GuildService` — `create`, `findById`, `addMember`, `removeMember`
- `GuildController` — guild CRUD and membership management endpoints
- Unit tests cover creation, member lifecycle, and not-found handling

Closes #306