### PR TITLE
feat: Puzzle Library and Catalog Service setup

### DIFF
--- a/microservices/puzzle-library-service/nest-cli.json
+++ b/microservices/puzzle-library-service/nest-cli.json
@@ -1,0 +1,1 @@
+{"$schema": "https://json.schemastore.org/nest-cli", "collection": "@nestjs/schematics", "sourceRoot": "src", "compilerOptions": {"deleteOutDir": true}}

--- a/microservices/puzzle-library-service/package.json
+++ b/microservices/puzzle-library-service/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "puzzle-library-service",
+  "version": "0.0.1",
+  "description": "Puzzle library and catalog service",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.4",
+    "@nestjs/core": "^10.4.4",
+    "@nestjs/platform-express": "^10.4.4",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.5",
+    "@nestjs/testing": "^10.4.4",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.15",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js","json","ts"],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {"^.+\\.(t|j)s$": "ts-jest"},
+    "testEnvironment": "node"
+  }
+}

--- a/microservices/puzzle-library-service/src/app.module.ts
+++ b/microservices/puzzle-library-service/src/app.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { PuzzleLibraryModule } from './puzzle-library/puzzle-library.module';
+
+@Module({ imports: [PuzzleLibraryModule] })
+export class AppModule {}

--- a/microservices/puzzle-library-service/src/main.ts
+++ b/microservices/puzzle-library-service/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  const port = parseInt(process.env.SERVICE_PORT || '3013', 10);
+  await app.listen(port);
+  console.log(`Puzzle Library Service running on port ${port}`);
+}
+bootstrap();

--- a/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.controller.spec.ts
+++ b/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.controller.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { PuzzleLibraryController } from './puzzle-library.controller';
+import { PuzzleLibraryService } from './puzzle-library.service';
+
+describe('PuzzleLibraryController', () => {
+  let ctrl: PuzzleLibraryController;
+  beforeEach(async () => {
+    const m: TestingModule = await Test.createTestingModule({
+      controllers: [PuzzleLibraryController], providers: [PuzzleLibraryService],
+    }).compile();
+    ctrl = m.get(PuzzleLibraryController);
+  });
+  it('should be defined', () => expect(ctrl).toBeDefined());
+  it('creates and retrieves a puzzle', () => {
+    const p = ctrl.create('Riddle 1', 'logic', 'easy');
+    expect(p.title).toBe('Riddle 1');
+    expect(ctrl.findOne(p.id).category).toBe('logic');
+  });
+  it('filters by category', () => {
+    ctrl.create('A', 'math', 'hard');
+    ctrl.create('B', 'logic', 'easy');
+    expect(ctrl.findAll('math')).toHaveLength(1);
+  });
+  it('throws for unknown puzzle', () => {
+    expect(() => ctrl.findOne('x')).toThrow(NotFoundException);
+  });
+});

--- a/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.controller.ts
+++ b/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { PuzzleLibraryService, Difficulty } from './puzzle-library.service';
+
+@Controller('puzzles')
+export class PuzzleLibraryController {
+  constructor(private readonly svc: PuzzleLibraryService) {}
+
+  @Post()
+  create(@Body('title') t: string, @Body('category') c: string, @Body('difficulty') d: Difficulty) {
+    return this.svc.create(t, c, d);
+  }
+
+  @Get()
+  findAll(@Query('category') cat?: string) { return this.svc.findAll(cat); }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) { return this.svc.findById(id); }
+
+  @Post(':id/tags')
+  addTag(@Param('id') id: string, @Body('tag') tag: string) { return this.svc.addTag(id, tag); }
+}

--- a/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.module.ts
+++ b/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { PuzzleLibraryController } from './puzzle-library.controller';
+import { PuzzleLibraryService } from './puzzle-library.service';
+
+@Module({ controllers: [PuzzleLibraryController], providers: [PuzzleLibraryService] })
+export class PuzzleLibraryModule {}

--- a/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.service.ts
+++ b/microservices/puzzle-library-service/src/puzzle-library/puzzle-library.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+export type Difficulty = 'easy' | 'medium' | 'hard';
+export interface Puzzle { id: string; title: string; category: string; tags: string[]; difficulty: Difficulty; }
+
+@Injectable()
+export class PuzzleLibraryService {
+  private readonly puzzles: Puzzle[] = [];
+
+  create(title: string, category: string, difficulty: Difficulty): Puzzle {
+    const p: Puzzle = { id: Date.now().toString(), title, category, tags: [], difficulty };
+    this.puzzles.push(p);
+    return p;
+  }
+
+  findAll(category?: string): Puzzle[] {
+    return category ? this.puzzles.filter((p) => p.category === category) : [...this.puzzles];
+  }
+
+  findById(id: string): Puzzle {
+    const p = this.puzzles.find((x) => x.id === id);
+    if (!p) throw new NotFoundException(`Puzzle ${id} not found`);
+    return p;
+  }
+
+  addTag(id: string, tag: string): Puzzle {
+    const p = this.findById(id);
+    if (!p.tags.includes(tag)) p.tags.push(tag);
+    return p;
+  }
+}

--- a/microservices/puzzle-library-service/tsconfig.build.json
+++ b/microservices/puzzle-library-service/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends": "./tsconfig.json", "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]}

--- a/microservices/puzzle-library-service/tsconfig.json
+++ b/microservices/puzzle-library-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2020",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Initialise `microservices/puzzle-library-service` as a standalone NestJS app (port 3013)
- `PuzzleLibraryService` — `create`, `findAll` (optional category filter), `findById`, `addTag`
- `PuzzleLibraryController` — REST endpoints for puzzle catalog management
- Unit tests cover CRUD and category filtering

Closes #307