### PR TITLE
feat: Seasonal Event Management Service setup

### DIFF
--- a/microservices/seasonal-event-service/nest-cli.json
+++ b/microservices/seasonal-event-service/nest-cli.json
@@ -1,0 +1,1 @@
+{"$schema": "https://json.schemastore.org/nest-cli", "collection": "@nestjs/schematics", "sourceRoot": "src", "compilerOptions": {"deleteOutDir": true}}

--- a/microservices/seasonal-event-service/package.json
+++ b/microservices/seasonal-event-service/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "seasonal-event-service",
+  "version": "0.0.1",
+  "description": "Seasonal event management service",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.4",
+    "@nestjs/core": "^10.4.4",
+    "@nestjs/platform-express": "^10.4.4",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.5",
+    "@nestjs/testing": "^10.4.4",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.15",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js","json","ts"],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {"^.+\\.(t|j)s$": "ts-jest"},
+    "testEnvironment": "node"
+  }
+}

--- a/microservices/seasonal-event-service/src/app.module.ts
+++ b/microservices/seasonal-event-service/src/app.module.ts
@@ -1,0 +1,5 @@
+import { Module } from '@nestjs/common';
+import { SeasonalEventModule } from './seasonal-event/seasonal-event.module';
+
+@Module({ imports: [SeasonalEventModule] })
+export class AppModule {}

--- a/microservices/seasonal-event-service/src/main.ts
+++ b/microservices/seasonal-event-service/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  const port = parseInt(process.env.SERVICE_PORT || '3014', 10);
+  await app.listen(port);
+  console.log(`Seasonal Event Service running on port ${port}`);
+}
+bootstrap();

--- a/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.controller.spec.ts
+++ b/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.controller.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { SeasonalEventController } from './seasonal-event.controller';
+import { SeasonalEventService } from './seasonal-event.service';
+
+describe('SeasonalEventController', () => {
+  let ctrl: SeasonalEventController;
+  beforeEach(async () => {
+    const m: TestingModule = await Test.createTestingModule({
+      controllers: [SeasonalEventController], providers: [SeasonalEventService],
+    }).compile();
+    ctrl = m.get(SeasonalEventController);
+  });
+  it('should be defined', () => expect(ctrl).toBeDefined());
+  it('creates an event and lists it', () => {
+    ctrl.create('Summer Fest', 'summer', '2026-06-01', '2026-08-31');
+    expect(ctrl.findAll()).toHaveLength(1);
+  });
+  it('activates an event', () => {
+    const e = ctrl.create('Harvest', 'autumn', '2026-09-01', '2026-11-30');
+    expect(ctrl.activate(e.id).active).toBe(true);
+  });
+  it('throws for unknown event', () => {
+    expect(() => ctrl.activate('ghost')).toThrow(NotFoundException);
+  });
+});

--- a/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.controller.ts
+++ b/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { SeasonalEventService } from './seasonal-event.service';
+
+@Controller('seasonal-events')
+export class SeasonalEventController {
+  constructor(private readonly svc: SeasonalEventService) {}
+
+  @Post()
+  create(
+    @Body('name') name: string, @Body('season') season: string,
+    @Body('startDate') start: string, @Body('endDate') end: string,
+  ) {
+    return this.svc.create(name, season, start, end);
+  }
+
+  @Get()
+  findAll() { return this.svc.findAll(); }
+
+  @Get('active')
+  findActive() { return this.svc.findActive(); }
+
+  @Post(':id/activate')
+  activate(@Param('id') id: string) { return this.svc.activate(id); }
+}

--- a/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.module.ts
+++ b/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+import { SeasonalEventController } from './seasonal-event.controller';
+import { SeasonalEventService } from './seasonal-event.service';
+
+@Module({ controllers: [SeasonalEventController], providers: [SeasonalEventService] })
+export class SeasonalEventModule {}

--- a/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.service.ts
+++ b/microservices/seasonal-event-service/src/seasonal-event/seasonal-event.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+export interface SeasonalEvent {
+  id: string; name: string; season: string;
+  startDate: string; endDate: string; active: boolean;
+}
+
+@Injectable()
+export class SeasonalEventService {
+  private readonly events: SeasonalEvent[] = [];
+
+  create(name: string, season: string, startDate: string, endDate: string): SeasonalEvent {
+    const e: SeasonalEvent = { id: Date.now().toString(), name, season, startDate, endDate, active: false };
+    this.events.push(e);
+    return e;
+  }
+
+  findAll(): SeasonalEvent[] { return [...this.events]; }
+
+  findActive(): SeasonalEvent[] {
+    const now = new Date().toISOString();
+    return this.events.filter((e) => e.startDate <= now && e.endDate >= now);
+  }
+
+  activate(id: string): SeasonalEvent {
+    const e = this.events.find((x) => x.id === id);
+    if (!e) throw new NotFoundException(`Event ${id} not found`);
+    e.active = true;
+    return e;
+  }
+}

--- a/microservices/seasonal-event-service/tsconfig.build.json
+++ b/microservices/seasonal-event-service/tsconfig.build.json
@@ -1,0 +1,1 @@
+{"extends": "./tsconfig.json", "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]}

--- a/microservices/seasonal-event-service/tsconfig.json
+++ b/microservices/seasonal-event-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2020",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Initialise `microservices/seasonal-event-service` as a standalone NestJS app (port 3014)
- `SeasonalEventService` — `create`, `findAll`, `findActive` (date-range filter), `activate`
- `SeasonalEventController` — `POST`, `GET`, `GET active`, `POST :id/activate`
- Unit tests cover creation, activation, and not-found handling

Closes #304