### PR TITLE
feat: scaffold daily challenge service

### DIFF
--- a/microservices/daily-challenge-service/src/app.module.ts
+++ b/microservices/daily-challenge-service/src/app.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ChallengeController } from './challenge/challenge.controller';
+import { ChallengeService } from './challenge/challenge.service';
+import { Challenge } from './challenge/challenge.entity';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      entities: [Challenge],
+      synchronize: false,
+    }),
+    TypeOrmModule.forFeature([Challenge]),
+  ],
+  controllers: [ChallengeController],
+  providers: [ChallengeService],
+})
+export class AppModule {}

--- a/microservices/daily-challenge-service/src/challenge/challenge.controller.ts
+++ b/microservices/daily-challenge-service/src/challenge/challenge.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { ChallengeService } from './challenge.service';
+
+@Controller('challenges')
+export class ChallengeController {
+  constructor(private readonly service: ChallengeService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Get('today')
+  findToday() {
+    return this.service.findToday();
+  }
+
+  @Post()
+  create(@Body() body: { title: string; scheduledDate: string }) {
+    return this.service.create(body.title, body.scheduledDate);
+  }
+}

--- a/microservices/daily-challenge-service/src/challenge/challenge.entity.ts
+++ b/microservices/daily-challenge-service/src/challenge/challenge.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('challenges')
+export class Challenge {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ type: 'date' })
+  scheduledDate: string;
+
+  @Column({ default: false })
+  completed: boolean;
+
+  @Column({ default: 0 })
+  streak: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/microservices/daily-challenge-service/src/challenge/challenge.service.ts
+++ b/microservices/daily-challenge-service/src/challenge/challenge.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Challenge } from './challenge.entity';
+
+@Injectable()
+export class ChallengeService {
+  constructor(
+    @InjectRepository(Challenge)
+    private readonly repo: Repository<Challenge>,
+  ) {}
+
+  findAll(): Promise<Challenge[]> {
+    return this.repo.find({ order: { scheduledDate: 'DESC' } });
+  }
+
+  findToday(): Promise<Challenge | null> {
+    const today = new Date().toISOString().split('T')[0];
+    return this.repo.findOne({ where: { scheduledDate: today } });
+  }
+
+  create(title: string, scheduledDate: string): Promise<Challenge> {
+    const challenge = this.repo.create({ title, scheduledDate });
+    return this.repo.save(challenge);
+  }
+}

--- a/microservices/daily-challenge-service/src/main.ts
+++ b/microservices/daily-challenge-service/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(process.env.PORT ?? 3010);
+}
+bootstrap();


### PR DESCRIPTION
## Summary
Initializes the daily challenge service microservice under `microservices/daily-challenge-service` with NestJS, TypeORM entities, service layer, and REST controller for rotating daily puzzles and tracking streaks.

## Changes
- Add `AppModule` with PostgreSQL/TypeORM configuration
- Add `Challenge` entity with scheduled date and streak tracking
- Add `ChallengeService` with today's challenge lookup
- Add `ChallengeController` exposing REST endpoints
- Add `main.ts` entry point

closes #310