### PR TITLE
feat: scaffold loyalty program and points service

### DIFF
--- a/microservices/loyalty-service/src/app.module.ts
+++ b/microservices/loyalty-service/src/app.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LoyaltyController } from './loyalty/loyalty.controller';
+import { LoyaltyService } from './loyalty/loyalty.service';
+import { LoyaltyPoints } from './loyalty/loyalty.entity';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      entities: [LoyaltyPoints],
+      synchronize: false,
+    }),
+    TypeOrmModule.forFeature([LoyaltyPoints]),
+  ],
+  controllers: [LoyaltyController],
+  providers: [LoyaltyService],
+})
+export class AppModule {}

--- a/microservices/loyalty-service/src/loyalty/loyalty.controller.ts
+++ b/microservices/loyalty-service/src/loyalty/loyalty.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import { LoyaltyService } from './loyalty.service';
+
+@Controller('loyalty')
+export class LoyaltyController {
+  constructor(private readonly service: LoyaltyService) {}
+
+  @Get(':userId')
+  getPoints(@Param('userId') userId: string) {
+    return this.service.getPoints(userId);
+  }
+
+  @Post(':userId/add')
+  addPoints(@Param('userId') userId: string, @Body() body: { amount: number }) {
+    return this.service.addPoints(userId, body.amount);
+  }
+}

--- a/microservices/loyalty-service/src/loyalty/loyalty.entity.ts
+++ b/microservices/loyalty-service/src/loyalty/loyalty.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, UpdateDateColumn } from 'typeorm';
+
+@Entity('loyalty_points')
+export class LoyaltyPoints {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  userId: string;
+
+  @Column({ default: 0 })
+  points: number;
+
+  @Column({ default: 'bronze' })
+  tier: string;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/microservices/loyalty-service/src/loyalty/loyalty.service.ts
+++ b/microservices/loyalty-service/src/loyalty/loyalty.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { LoyaltyPoints } from './loyalty.entity';
+
+const TIER_THRESHOLDS = { silver: 500, gold: 2000, platinum: 5000 };
+
+@Injectable()
+export class LoyaltyService {
+  constructor(
+    @InjectRepository(LoyaltyPoints)
+    private readonly repo: Repository<LoyaltyPoints>,
+  ) {}
+
+  async getPoints(userId: string): Promise<LoyaltyPoints | null> {
+    return this.repo.findOne({ where: { userId } });
+  }
+
+  async addPoints(userId: string, amount: number): Promise<LoyaltyPoints> {
+    let record = await this.repo.findOne({ where: { userId } });
+    if (!record) record = this.repo.create({ userId, points: 0 });
+    record.points += amount;
+    record.tier = this.calculateTier(record.points);
+    return this.repo.save(record);
+  }
+
+  private calculateTier(points: number): string {
+    if (points >= TIER_THRESHOLDS.platinum) return 'platinum';
+    if (points >= TIER_THRESHOLDS.gold) return 'gold';
+    if (points >= TIER_THRESHOLDS.silver) return 'silver';
+    return 'bronze';
+  }
+}

--- a/microservices/loyalty-service/src/main.ts
+++ b/microservices/loyalty-service/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(process.env.PORT ?? 3015);
+}
+bootstrap();


### PR DESCRIPTION
## Summary
Initializes the loyalty service microservice under `microservices/loyalty-service` with NestJS, TypeORM entities, service layer, and REST controller for tracking player points and tier progression.

## Changes
- Add `AppModule` with PostgreSQL/TypeORM configuration
- Add `LoyaltyPoints` entity with tier tracking
- Add `LoyaltyService` with points accumulation and automatic tier calculation (bronze/silver/gold/platinum)
- Add `LoyaltyController` exposing REST endpoints
- Add `main.ts` entry point

closes #315