### PR TITLE
feat: scaffold digital asset management service

### DIFF
--- a/microservices/asset-service/src/app.module.ts
+++ b/microservices/asset-service/src/app.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AssetController } from './asset/asset.controller';
+import { AssetService } from './asset/asset.service';
+import { Asset } from './asset/asset.entity';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      entities: [Asset],
+      synchronize: false,
+    }),
+    TypeOrmModule.forFeature([Asset]),
+  ],
+  controllers: [AssetController],
+  providers: [AssetService],
+})
+export class AppModule {}

--- a/microservices/asset-service/src/asset/asset.controller.ts
+++ b/microservices/asset-service/src/asset/asset.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Post, Delete, Body, Param } from '@nestjs/common';
+import { AssetService } from './asset.service';
+
+@Controller('assets')
+export class AssetController {
+  constructor(private readonly service: AssetService) {}
+
+  @Get('owner/:ownerId')
+  findByOwner(@Param('ownerId') ownerId: string) {
+    return this.service.findByOwner(ownerId);
+  }
+
+  @Get(':id')
+  findById(@Param('id') id: string) {
+    return this.service.findById(id);
+  }
+
+  @Post()
+  register(@Body() body: { ownerId: string; filename: string; mimeType: string; sizeBytes: number }) {
+    return this.service.register(body.ownerId, body.filename, body.mimeType, body.sizeBytes);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.service.delete(id);
+  }
+}

--- a/microservices/asset-service/src/asset/asset.entity.ts
+++ b/microservices/asset-service/src/asset/asset.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('assets')
+export class Asset {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  ownerId: string;
+
+  @Column()
+  filename: string;
+
+  @Column()
+  mimeType: string;
+
+  @Column({ type: 'bigint', default: 0 })
+  sizeBytes: number;
+
+  @Column({ nullable: true })
+  storageKey: string | null;
+
+  @Column({ default: 'active' })
+  status: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/microservices/asset-service/src/asset/asset.service.ts
+++ b/microservices/asset-service/src/asset/asset.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Asset } from './asset.entity';
+
+@Injectable()
+export class AssetService {
+  constructor(
+    @InjectRepository(Asset)
+    private readonly repo: Repository<Asset>,
+  ) {}
+
+  findByOwner(ownerId: string): Promise<Asset[]> {
+    return this.repo.find({ where: { ownerId, status: 'active' } });
+  }
+
+  findById(id: string): Promise<Asset | null> {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  register(ownerId: string, filename: string, mimeType: string, sizeBytes: number): Promise<Asset> {
+    const asset = this.repo.create({ ownerId, filename, mimeType, sizeBytes });
+    return this.repo.save(asset);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.repo.update(id, { status: 'deleted' });
+  }
+}

--- a/microservices/asset-service/src/main.ts
+++ b/microservices/asset-service/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(process.env.PORT ?? 3017);
+}
+bootstrap();


### PR DESCRIPTION
## Summary
Initializes the asset management service microservice under `microservices/asset-service` with NestJS, TypeORM entities, service layer, and REST controller for managing uploaded files and digital assets.

## Changes
- Add `AppModule` with PostgreSQL/TypeORM configuration
- Add `Asset` entity with owner, mime type, size, and soft-delete status
- Add `AssetService` with register, lookup, and soft-delete operations
- Add `AssetController` exposing REST endpoints
- Add `main.ts` entry point

closes #317